### PR TITLE
Only process jobs with handlers available

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,14 @@
+'use strict'
+const util = require('util')
+
+function JobQueueEmpty(message, extra) {
+    Error.captureStackTrace(this, this.constructor)
+    this.name = this.constructor.name
+    this.message = message
+    this.extra = extra
+};
+
+util.inherits(JobQueueEmpty, Error);
+
+exports.JobQueueEmpty = JobQueueEmpty
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird')
 const pgp = require('pg-promise')({promiseLib: Promise})
 const Job = require('./job')
 const _ = require('lodash')
+const errors = require('./errors')
 
 var jobHandlers = {}
 var db
@@ -62,19 +63,23 @@ function addJob(job) {
 }
 
 function processNextJob() {
+    var types = _.keys(jobHandlers)
     return db.tx(function(t) {
-        return t.one('SELECT * FROM pending_jobs(1)')
-    }).then(function(result) {
-        var handler = jobHandlers[result.type]
-        if (!handler) {
-            // no handler is defined, so ignore the job (but output a warning)
-            console.warn("skipping job #{}, because no handler is available for type '{}'".format(result.id, result.type))
-            return db.none('UPDATE "JobQueue" SET "state"=${state}', {state: 'waiting'})
+        return t.func('pending_jobs', [1, types])
+    }).then(function(results) {
+
+        if (results.length != 1) {
+            throw new errors.JobQueueEmpty()
         }
+
+        var result = results[0]
+        var handler = jobHandlers[result.type]
         var job = new Job(result, db)
+
         return Promise.try(function() {
-            return jobHandlers[result.type](job, self)
-        }).catch((e) => {
+            return jobHandlers[result.type](job)
+        })
+        .catch((e) => {
             return job.fail(e.message)
         })
     })
@@ -92,6 +97,7 @@ function startProcessing() {
             return Promise.resolve()
         }
         processNextJob().catch(function(e) {
+            // ignore job errors because they are handled by processNextJob() and we must continue our loop
             
         })
         .finally(function() {
@@ -130,3 +136,4 @@ exports.getFailedJobs = getFailedJobs
 exports.processAllJobs = processAllJobs
 exports.waitingCount = waitingCount
 exports.pgp = pgp
+exports.errors = errors


### PR DESCRIPTION
Previously we would process any jobs, and print a warning if the job
didn't have a matching handler then resubmit it. This caused an infinite
loop.

This commit changes behaviour so jobs are only processed if a handler is
registered for the job type.
