### PR TITLE
Add support for nested job handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const jobqueue = require('pg-job-queue')
 const queue = new jobqueue('postgres://postgres@localhost/my-job-queue')
 
 queue.addJob({
-    type: 'sendEmail',
+    type: 'sendmail.welcome',
     data: {
         toAddress: 'demo@example.com',
         message: 'hello'
@@ -38,12 +38,15 @@ queue.addJob({
 const jobqueue = require('pg-job-queue')
 const queue = new jobqueue('postgres://postgres@localhost/my-job-queue')
 
+// define your job handlers
 var handlers = {
-    sendEmail: function(job) {
-        return sendMail(job.data.toAddress, job.data.message)
-        .then(() => {
-            return job.finish()
-        })
+    sendmail: {
+        welcome: function(job) {
+            return sendMail(job.data.toAddress, job.data.message)
+            .then(() => {
+                return job.finish()
+            })
+        }
     }
 }
 queue.addHandlers(handlers)
@@ -56,10 +59,12 @@ queue.startProcessing()
 ##### 1. Create handlers.js file
 ```javascript
 module.exports = {
-    sendEmail: function(job) {
-        return sendMail(job.data.toAddress, job.data.message).then(() => {
-            return job.finish()
-        })
+    sendmail: {
+        welcome: function(job) {
+            return sendMail(job.data.toAddress, job.data.message).then(() => {
+                return job.finish()
+            })
+        }
     }
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,8 +105,15 @@ JobQueue.prototype.getAvailableJobTypes = function() {
 
 JobQueue.prototype.resolveHandler = function(path)
 {
-    return _(this.jobHandlers).at(path).compact().head()
-
+    // try and return the resolved path (e.g. handlers.job.path
+    var byPath = _(this.jobHandlers).at(path).compact().head()
+    if (byPath) {
+        return byPath
+    }
+    else {
+        // maybe there is a handler defined with the path (e.g. handlers['job.path'])
+        return this.jobHandlers[path]
+    }
 }
 
 /*

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,12 +86,35 @@ JobQueue.prototype.addJob = function(job) {
     return this.db.none(query, job)
 }
 
+JobQueue.prototype.getAvailableJobTypes = function() {
+    function recurse(val, key) {
+
+        if (_.isObject(val) && !_.isFunction(val)) {
+            return _.map(val, (subval, subkey) => {
+                key += '.' + subkey
+                return recurse(subval, key)
+            })
+        }
+        else {
+            return key
+        }
+    }
+
+    return _(this.jobHandlers).map(recurse).flattenDeep().value()
+}
+
+JobQueue.prototype.resolveHandler = function(path)
+{
+    return _(this.jobHandlers).at(path).compact().head()
+
+}
+
 /*
 Grab the next job with a known handler, process it.
 If no jobs are found, throw errors.JobQueueEmpty
 */
 JobQueue.prototype.processNextJob = function() {
-    var types = _.keys(this.jobHandlers)
+    var types = this.getAvailableJobTypes()
 
     // we use a task, to ensure the same connection is used
     // this is important because we use a session-level advisory lock
@@ -105,7 +128,8 @@ JobQueue.prototype.processNextJob = function() {
             var job = new Job(result, this.db)
 
             return Promise.try(() => {
-                return this.jobHandlers[result.type](job)
+                var handler = this.resolveHandler(result.type)
+                return handler(job)
             }).then(() => {
                 // the job was not destroyed, finished or rescheduled
                 // we mark the job as finished

--- a/test/queue.js
+++ b/test/queue.js
@@ -98,7 +98,6 @@ describe('Job Queue', function() {
     })
 
     it('should accept a new job with a path type', function() {
-
         function jobHandler(job, queue) {
             // send email to job.data.recipient, message=job.data.message
             return job.finish()
@@ -115,6 +114,7 @@ describe('Job Queue', function() {
             }
         })
 
+        // define the job
         var job = {
             type: 'emails.subgroup.welcome',
             data: {
@@ -122,9 +122,7 @@ describe('Job Queue', function() {
                 message: 'HELLO'
             }
         }
-
-
-        // add a job
+        // add the job
         return this.queue.addJob(job).then(() => {
             // process the job
             return this.queue.processNextJob().then(() => {

--- a/test/queue.js
+++ b/test/queue.js
@@ -57,7 +57,6 @@ describe('Job Queue', function() {
             job = _.extend({}, this.validJob, {maxAttempts: -123})
             expect(() => this.queue.addJob(job)).to.throw(TypeError)
         })
-
     })
 
     it('should accept a new job and then process it once', function() {
@@ -97,6 +96,91 @@ describe('Job Queue', function() {
             })
         })
     })
+
+    it('should accept a new job with a path type', function() {
+
+        function jobHandler(job, queue) {
+            // send email to job.data.recipient, message=job.data.message
+            return job.finish()
+        }
+
+        var spy = sinon.spy(jobHandler)
+
+        // setup a single job handler
+        this.queue.setHandlers({
+            emails: {
+                subgroup: {
+                    welcome: spy
+                }
+            }
+        })
+
+        var job = {
+            type: 'emails.subgroup.welcome',
+            data: {
+                recipient: 'user@example.com',
+                message: 'HELLO'
+            }
+        }
+
+
+        // add a job
+        return this.queue.addJob(job).then(() => {
+            // process the job
+            return this.queue.processNextJob().then(() => {
+
+                // check the handler was called correctly
+                expect(spy.calledOnce).to.be.true
+                expect(spy.getCall(0).args[0].data).to.deep.equal(job.data)
+
+                // try and process the job again (should fail)
+                return expect(this.queue.processNextJob()).to.eventually.be.rejected
+            })
+        })
+    })
+
+    it('should resolve a job handler from a path', function() {
+
+        var handlers = {
+            email: {
+                subgroup: {
+                    welcome: () => {}
+                }
+            },
+            sendEmail: () => {}
+        }
+        this.queue.setHandlers(handlers)
+        var welcome = this.queue.resolveHandler('email.subgroup.welcome')
+        expect(welcome).to.equal(handlers.email.subgroup.welcome)
+        var sendEmail = handlers.sendEmail
+        expect(sendEmail).to.equal(handlers.sendEmail)
+    })
+
+    it('should determine available job types', function() {
+        var handlers = {
+            testJob: () => {},
+            emails: {
+                subgroup: {
+                    welcome: () => {},
+                    goodbye: () => {},
+                }
+            }
+        }
+        this.queue.setHandlers(handlers)
+        var expected = [
+            'testJob',
+            'emails.subgroup.welcome',
+            'emails.subgroup.goodbye',
+        ]
+        var types = this.queue.getAvailableJobTypes()
+
+        // sort them both
+        types = _.sortBy(types)
+        expected = _.sortBy(expected)
+        expect(_.isEqual(types, expected))
+    })
+
+
 
     it('should mark a job as failed if it throws an exception', function() {
         this.queue.setHandlers({

--- a/test/queue.js
+++ b/test/queue.js
@@ -97,7 +97,7 @@ describe('Job Queue', function() {
         })
     })
 
-    it('should accept a new job with a path type', function() {
+    it('should resolve job types as paths', function() {
         function jobHandler(job, queue) {
             // send email to job.data.recipient, message=job.data.message
             return job.finish()


### PR DESCRIPTION
Previously the job type was a simple string, e.g. 'email.welcome' would use the handler handlers['email.welcome'].

This PR adds support for nesting of job handlers, so 'email.welcome' will use the handler handlers.email.welcome.

Backwards compatibility is maintained, e.g. 'email.welcome' will use the handler handlers['email.welcome'], if handlers.email.welcome is not defined.
