### PR TITLE
Update job.js

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -41,9 +41,9 @@ Job.prototype.reschedule = function(date) {
 }
 
 Job.prototype.fail = function (error, rescheduleFor) {
-    var self = this;
+    let self = this;
     self.handled = true;
-    return self.db.task(function*(t) {
+    return self.db.tx(function*(t) {
         yield t.none('UPDATE "JobQueue" SET "lastFailureMessage"=${failureMessage}, "failedAttempts"="failedAttempts"+1, "lastRun"=NOW() WHERE "id"=${id}', {
             id: self.id,
             failureMessage: error.message
@@ -58,8 +58,8 @@ Job.prototype.fail = function (error, rescheduleFor) {
             });
         }
         // reschedule the job to run in 3 minute
-        var now = new Date();
-        var minute = 3 * 60 * 1000;
+        let now = new Date();
+        let minute = 3 * 60 * 1000;
         self.scheduledFor = rescheduleFor || new Date(now.getTime() + minute);
         self.state = 'waiting';
         return yield t.none('UPDATE "JobQueue" SET "state"=${state}, "scheduledFor"=${scheduledFor} WHERE "id"=${id}', {

--- a/lib/job.js
+++ b/lib/job.js
@@ -40,37 +40,36 @@ Job.prototype.reschedule = function(date) {
     .then(() => this.queue.logEvent('finished', this))
 }
 
-Job.prototype.fail = function(error, rescheduleFor) {
-    this.handled = true
-    return this.db.none('UPDATE "JobQueue" SET "lastFailureMessage"=${failureMessage}, "failedAttempts"="failedAttempts"+1, "lastRun"=NOW() WHERE "id"=${id}', {
-        id: this.id,
-        failureMessage: error.message
-    }).then(() => {
-        return this.db.one('SELECT * FROM "JobQueue" WHERE "id"=${id}', {id: this.id}).then((result) => {
-            if (result.failedAttempts >= result.maxAttempts) {
-                // complete failure, ensure the job isn't run again
-                this.state = 'failed'
-                return this.db.none('UPDATE "JobQueue" SET "state"=${state} WHERE "id"=${id}', {
-                    id: this.id,
-                    state: this.state
-                })
-            }
-            else {
-                // reschedule the job to run in 3 minute
-                var now = new Date()
-                var minute = 3 * 60 * 1000
-                this.scheduledFor = rescheduleFor || new Date(now.getTime() + minute)
-                this.state = 'waiting'
-                return this.db.none('UPDATE "JobQueue" SET "state"=${state}, "scheduledFor"=${scheduledFor} WHERE "id"=${id}', {
-                    id: this.id,
-                    state: this.state,
-                    scheduledFor: this.scheduledFor
-                })
-            }
-        })
+Job.prototype.fail = function (error, rescheduleFor) {
+    var self = this;
+    self.handled = true;
+    return self.db.task(function*(t) {
+        yield t.none('UPDATE "JobQueue" SET "lastFailureMessage"=${failureMessage}, "failedAttempts"="failedAttempts"+1, "lastRun"=NOW() WHERE "id"=${id}', {
+            id: self.id,
+            failureMessage: error.message
+        });
+        let JobQueue = yield t.one('SELECT * FROM "JobQueue" WHERE "id"=${id}', {id: self.id});
+        if (JobQueue.failedAttempts >= JobQueue.maxAttempts) {
+            // complete failure, ensure the job isn't run again
+            self.state = 'failed';
+            return yield t.none('UPDATE "JobQueue" SET "state"=${state} WHERE "id"=${id}', {
+                id: self.id,
+                state: self.state
+            });
+        }
+        // reschedule the job to run in 3 minute
+        var now = new Date();
+        var minute = 3 * 60 * 1000;
+        self.scheduledFor = rescheduleFor || new Date(now.getTime() + minute);
+        self.state = 'waiting';
+        return yield t.none('UPDATE "JobQueue" SET "state"=${state}, "scheduledFor"=${scheduledFor} WHERE "id"=${id}', {
+            id: self.id,
+            state: self.state,
+            scheduledFor: self.scheduledFor
+        });
     })
-    .then(() => this.queue.logEvent('failed', this))
-    .then(() => this.queue.logError(error, this))
-}
+        .then(() => self.queue.logEvent('failed', self))
+        .then(() => self.queue.logError(error, self));
+};
 
 module.exports = Job


### PR DESCRIPTION
1. When executing more than one query at a time, tasks should be used;
2. Tasks are most readable when used with generators;
3. `self` is a better way to refer to `this` safely, as you jump call context
4. Simplifying the code
